### PR TITLE
Add CSV request handling and example

### DIFF
--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -254,9 +254,7 @@ class BaseRequestHandler(ABC):
             if content_type.startswith("text/csv"):
                 charset = "utf-8"
                 if "charset=" in content_type:
-                    charset = (
-                        content_type.split("charset=")[-1].split(";")[0].strip()
-                    )
+                    charset = content_type.split("charset=")[-1].split(";")[0].strip()
                 body = await request.body()
                 return body.decode(charset)
             if content_type == "application/x-www-form-urlencoded" or content_type.startswith("multipart/form-data"):

--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -254,7 +254,9 @@ class BaseRequestHandler(ABC):
             if content_type.startswith("text/csv"):
                 charset = "utf-8"
                 if "charset=" in content_type:
-                    charset = content_type.split("charset=")[-1].split(";")[0].strip()
+                    charset = (
+                        content_type.split("charset=")[-1].split(";")[0].strip()
+                    )
                 body = await request.body()
                 return body.decode(charset)
             if content_type == "application/x-www-form-urlencoded" or content_type.startswith("multipart/form-data"):

--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -251,6 +251,12 @@ class BaseRequestHandler(ABC):
         """Common request preparation logic."""
         if request_type == Request:
             content_type = request.headers.get("Content-Type", "")
+            if content_type.startswith("text/csv"):
+                charset = "utf-8"
+                if "charset=" in content_type:
+                    charset = content_type.split("charset=")[-1].split(";")[0].strip()
+                body = await request.body()
+                return body.decode(charset)
             if content_type == "application/x-www-form-urlencoded" or content_type.startswith("multipart/form-data"):
                 return await request.form()
             return await request.json()
@@ -814,7 +820,7 @@ class LitServer:
             time.sleep(0.05)
         logger.debug("One or more workers are ready to serve requests")
 
-    def _init_manager(self, num_api_servers: int):
+    def _init_manager(self, num_api_servers: int) -> mp.managers.BaseManager:
         manager = mp.Manager()
         self.transport_config.manager = manager
         self.transport_config.num_consumers = num_api_servers
@@ -833,7 +839,7 @@ class LitServer:
 
     def _perform_graceful_shutdown(
         self,
-        manager: mp.Manager,
+        manager: mp.managers.BaseManager,
         uvicorn_workers: List[Union[mp.Process, threading.Thread]],
         inference_workers: List[mp.Process],
         shutdown_reason: str = "normal",

--- a/src/litserve/test_examples/__init__.py
+++ b/src/litserve/test_examples/__init__.py
@@ -5,7 +5,12 @@ from litserve.test_examples.openai_spec_example import (
     TestAPIWithStructuredOutput,
     TestAPIWithToolCalls,
 )
-from litserve.test_examples.simple_example import SimpleBatchedAPI, SimpleLitAPI, SimpleStreamAPI, SimpleTorchAPI
+from litserve.test_examples.simple_example import (
+    SimpleBatchedAPI,
+    SimpleLitAPI,
+    SimpleStreamAPI,
+    SimpleTorchAPI,
+)
 from litserve.test_examples.csv_echo import CSVEchoAPI
 
 __all__ = [

--- a/src/litserve/test_examples/__init__.py
+++ b/src/litserve/test_examples/__init__.py
@@ -6,6 +6,7 @@ from litserve.test_examples.openai_spec_example import (
     TestAPIWithToolCalls,
 )
 from litserve.test_examples.simple_example import SimpleBatchedAPI, SimpleLitAPI, SimpleStreamAPI, SimpleTorchAPI
+from litserve.test_examples.csv_echo import CSVEchoAPI
 
 __all__ = [
     "SimpleLitAPI",
@@ -17,4 +18,5 @@ __all__ = [
     "TestAPIWithToolCalls",
     "OpenAIBatchContext",
     "SimpleStreamAPI",
+    "CSVEchoAPI",
 ]

--- a/src/litserve/test_examples/csv_echo.py
+++ b/src/litserve/test_examples/csv_echo.py
@@ -1,0 +1,21 @@
+from io import StringIO
+import csv
+from fastapi import Response
+
+from litserve.api import LitAPI
+
+
+class CSVEchoAPI(LitAPI):
+    def setup(self, device):
+        self.model = lambda rows: rows
+
+    def decode_request(self, request: str):
+        return list(csv.reader(StringIO(request)))
+
+    def predict(self, rows):
+        return self.model(rows)
+
+    def encode_response(self, output) -> Response:
+        buf = StringIO()
+        csv.writer(buf).writerows(output)
+        return Response(content=buf.getvalue(), media_type="text/csv")

--- a/src/litserve/transport/factory.py
+++ b/src/litserve/transport/factory.py
@@ -16,6 +16,7 @@ class TransportConfig(BaseModel):
     frontend_address: Optional[str] = None
     backend_address: Optional[str] = None
 
+
     class Config:
         arbitrary_types_allowed = True
 

--- a/src/litserve/transport/factory.py
+++ b/src/litserve/transport/factory.py
@@ -1,4 +1,4 @@
-from multiprocessing import Manager
+from multiprocessing.managers import BaseManager
 from typing import Literal, Optional
 
 from pydantic import BaseModel, Field
@@ -11,10 +11,13 @@ from litserve.transport.zmq_transport import ZMQTransport
 class TransportConfig(BaseModel):
     transport_type: Literal["mp", "zmq"] = "mp"
     num_consumers: int = Field(1, ge=1)
-    manager: Optional[Manager] = None
+    manager: Optional[BaseManager] = None
     consumer_id: Optional[int] = None
     frontend_address: Optional[str] = None
     backend_address: Optional[str] = None
+
+    class Config:
+        arbitrary_types_allowed = True
 
 
 def _create_zmq_transport(config: TransportConfig):

--- a/src/litserve/transport/process_transport.py
+++ b/src/litserve/transport/process_transport.py
@@ -1,13 +1,14 @@
 import asyncio
 from contextlib import suppress
-from multiprocessing import Manager, Queue
+from multiprocessing import Queue
+from multiprocessing.managers import BaseManager
 from typing import Any, List, Optional
 
 from litserve.transport.base import MessageTransport
 
 
 class MPQueueTransport(MessageTransport):
-    def __init__(self, manager: Manager, queues: List[Queue]):
+    def __init__(self, manager: BaseManager, queues: List[Queue]):
         self._queues = queues
         self._closed = False
 

--- a/tests/test_request_handlers.py
+++ b/tests/test_request_handlers.py
@@ -46,9 +46,10 @@ class MockServer:
 class MockRequest:
     """Mock FastAPI Request object for testing."""
 
-    def __init__(self, json_data=None, form_data=None, content_type="application/json"):
+    def __init__(self, json_data=None, form_data=None, body_data=None, content_type="application/json"):
         self._json_data = json_data or {}
         self._form_data = form_data or {}
+        self._body_data = body_data or b""
         self.headers = {"Content-Type": content_type}
 
     async def json(self):
@@ -58,6 +59,9 @@ class MockRequest:
 
     async def form(self):
         return self._form_data
+
+    async def body(self):
+        return self._body_data
 
 
 class TestRequestHandler(BaseRequestHandler):
@@ -92,3 +96,24 @@ async def test_request_handler_streaming(mock_event, mock_lit_api):
     response = await handler.handle_request(mock_request, Request)
     assert mock_server.request_queue.qsize() == 1
     assert response == "test-response"
+
+@pytest.mark.asyncio
+async def test_prepare_request_csv_utf8(mock_lit_api):
+    csv_text = "a,b\n1,2\nö,ä"
+    body = csv_text.encode("utf-8")
+    mock_server = MockServer(mock_lit_api)
+    handler = TestRequestHandler(mock_lit_api, mock_server)
+    mock_request = MockRequest(body_data=body, content_type="text/csv; charset=utf-8")
+    result = await handler._prepare_request(mock_request, Request)
+    assert result == csv_text
+
+
+@pytest.mark.asyncio
+async def test_prepare_request_csv_iso8859(mock_lit_api):
+    csv_text = "a,b\n1,2\nö,ä"
+    body = csv_text.encode("iso-8859-15")
+    mock_server = MockServer(mock_lit_api)
+    handler = TestRequestHandler(mock_lit_api, mock_server)
+    mock_request = MockRequest(body_data=body, content_type="text/csv; charset=ISO-8859-15")
+    result = await handler._prepare_request(mock_request, Request)
+    assert result == csv_text

--- a/tests/test_request_handlers.py
+++ b/tests/test_request_handlers.py
@@ -97,6 +97,7 @@ async def test_request_handler_streaming(mock_event, mock_lit_api):
     assert mock_server.request_queue.qsize() == 1
     assert response == "test-response"
 
+
 @pytest.mark.asyncio
 async def test_prepare_request_csv_utf8(mock_lit_api):
     csv_text = "a,b\n1,2\nö,ä"


### PR DESCRIPTION
## Summary
- support text/csv content bodies in `_prepare_request`
- add `CSVEchoAPI` example
- export the CSV example in the test examples package
- accept `BaseManager` in `TransportConfig`
- test UTF‑8 and ISO‑8859‑15 encoded CSV requests

## Testing
- `pre-commit run --files src/litserve/server.py src/litserve/test_examples/__init__.py src/litserve/test_examples/csv_echo.py src/litserve/transport/factory.py src/litserve/transport/process_transport.py tests/test_request_handlers.py` *(fails: RPC failed; HTTP 403)*
- `pytest tests/test_request_handlers.py::test_prepare_request_csv_utf8 tests/test_request_handlers.py::test_prepare_request_csv_iso8859 -q`

------
https://chatgpt.com/codex/tasks/task_e_6846b43bc8bc8332ad6d2ffc68b5a680